### PR TITLE
Added model specs and factories to ignore block length in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,6 @@ AllCops:
     - config.ru
     - Rakefile
     - config/routes.rb
-    - spec/factories/*
 
 Documentation:
   Enabled: false
@@ -42,6 +41,11 @@ Style/BlockComments:
 
 Style/BlockDelimiters:
   Enabled: false
+
+Style/BlockLength:
+  Exclude:
+    - spec/factories/*
+    - spec/models/*
 
 Style/CaseIndentation:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,9 +57,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
     bindex (0.5.0)
-    bootstrap-sass (3.3.7)
-      autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
     builder (3.2.3)
     byebug (9.0.6)
     codeclimate-engine-rb (0.4.0)
@@ -254,7 +251,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap!
-  bootstrap-sass
   byebug
   coffee-rails (~> 4.2)
   database_cleaner

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Character, type: :model do
   let(:character) { FactoryGirl.create :character }
 
   it { should validate_presence_of(:name) }
-	it { should validate_numericality_of(:force_rating).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
+  it { should validate_numericality_of(:force_rating).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
   it { should validate_presence_of(:user) }
   it { should validate_presence_of(:emotional_strength) }
   it { should validate_presence_of(:emotional_weakness) }
-	it { should validate_numericality_of(:conflict).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:morality).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(100) }
+  it { should validate_numericality_of(:conflict).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:morality).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(100) }
   it { should validate_presence_of(:gender) }
   it { should validate_numericality_of(:age).is_greater_than_or_equal_to(0) }
   it { should validate_presence_of(:height) }
@@ -19,19 +19,19 @@ RSpec.describe Character, type: :model do
   it { should validate_presence_of(:notable_features) }
   it { should validate_numericality_of(:total_xp).is_greater_than_or_equal_to(0) }
   it { should validate_numericality_of(:available_xp).is_greater_than_or_equal_to(0) }
-	it { should validate_numericality_of(:soak_value).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:threshold_wounds).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:current_wounds).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:threshold_strain).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:current_strain).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:ranged_defense).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:melee_defense).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
-	it { should validate_numericality_of(:brawn).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
-	it { should validate_numericality_of(:agility).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
-	it { should validate_numericality_of(:intellect).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
-	it { should validate_numericality_of(:cunning).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
-	it { should validate_numericality_of(:will_power).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
-	it { should validate_numericality_of(:presence).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
+  it { should validate_numericality_of(:soak_value).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:threshold_wounds).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:current_wounds).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:threshold_strain).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:current_strain).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:ranged_defense).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:melee_defense).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(99) }
+  it { should validate_numericality_of(:brawn).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
+  it { should validate_numericality_of(:agility).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
+  it { should validate_numericality_of(:intellect).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
+  it { should validate_numericality_of(:cunning).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
+  it { should validate_numericality_of(:will_power).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
+  it { should validate_numericality_of(:presence).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(5) }
   it { should validate_numericality_of(:credits).is_greater_than_or_equal_to(0) }
   it { should validate_presence_of(:motivations) }
   it { should validate_presence_of(:species) }


### PR DESCRIPTION
### What does this PR do?

* Adds factories and specs to ignoring list of rubocop's block length cop
* Fixed identation of character_spec to pass rubocop tests