### PR TITLE
Career model patch

### DIFF
--- a/app/controllers/careers_controller.rb
+++ b/app/controllers/careers_controller.rb
@@ -36,6 +36,7 @@ class CareersController < ApplicationController
 
   def upload
     Career.upload(params[:upload][:file])
+    redirect_to careers_path
   end
 
   private

--- a/app/models/career.rb
+++ b/app/models/career.rb
@@ -10,7 +10,7 @@ class Career < ApplicationRecord
   validates :name, :description, :source_page, :source_book, 
             :career_skills, :free_ranks, presence: true
 
-  validates :career_skills, length: { is: 6 }
+  validates :career_skills, length: { in: 1..10 }
 
   validates :source_page, :free_ranks, numericality: { only_integer: true }
 

--- a/spec/models/career_spec.rb
+++ b/spec/models/career_spec.rb
@@ -16,13 +16,28 @@ RSpec.describe Career, type: :model do
   it { should validate_presence_of(:career_skills) }
   it { should validate_numericality_of(:source_page).only_integer }
   it { should have_many(:characters) }
-  it "validates length of career_skills is 6" do
-    career = FactoryGirl.create(:career, career_skills: %w[Warrior Guardian Healer Sniper Tank Paladin])
+  it "validates length of career_skills as 6 is valid" do
+    career = FactoryGirl.build(:career, career_skills: %w[Warrior Guardian Healer Sniper Tank Paladin])
     expect(career).to be_valid
   end
 
-  it "validates length of career_skills is not 6" do
-    career = FactoryGirl.build(:career, career_skills: %w[Warrior Guardian])
+  it "validates length of career_skills as 1 is valid" do
+    career = FactoryGirl.build(:career, career_skills: %w[Healer])
+    expect(career).to be_valid
+  end
+
+  it "validates length of career_skills as 10 is valid" do
+    career = FactoryGirl.build(:career, career_skills: %w[Warrior Guardian Healer Sniper Tank Paladin Healer Sniper Tank Paladin])
+    expect(career).to be_valid
+  end
+
+  it "validates length of career_skills as 0 is not valid" do
+    career = FactoryGirl.build(:career, career_skills: [])
+    expect(career).not_to be_valid
+  end
+
+  it "validates length of career_skills as 11 is not valid" do
+    career = FactoryGirl.build(:career, career_skills: %w[Warrior Guardian Healer Sniper Tank Paladin Healer Sniper Tank Paladin Offtank])
     expect(career).not_to be_valid
   end
 


### PR DESCRIPTION
### What does this PR do?

* Changes the quantity of career_skills from 6 to be in 1..10
* Modifies the tests to satisfy the previous condition
* Adds redirect after upload